### PR TITLE
Add support for space-delimited subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,43 @@
-@oclif/command
+alto-command
 ===============
+
+This is a fork of [@oclif/command](https://github.com/oclif/command).
+The reason for this fork is to change this to allow space-separated subcommands rather than
+the heroku-style colon delimited.  This is a minimal change, which should allow this to be
+used with the rest of the `@oclif/*` system.
+
+Note that this accepts both the heroku style and the space-delimited style at the moment.
+
+### Notes/Next steps
+* This hasn't been particularly heavily tested, at this moment.
+* Other parts of the `@oclif/*` system will need to be alto-ized (e.g. the help plugin)
+* Would like to set up a "heroku" flag in the package hosting this one, and let that drive whether this does or does not accept colons.
+
+### Warning
+
+Consider this situation. You have a command like this:
+  ```
+  mycmd topic1 topic2 cmd arg  # that is, in heroku-land mycmd topic1:topic2:cmd arg
+  ```
+imagine you mis-type this:
+  ```
+  mycmd topic1 topic2 arg
+  ```
+and your arg happens to have the value "cmd". Then this will execute the command when you
+might have expected an error (this is hardly a surprise in the land of command line interfaces
+where many things like this can happy, but worth pointing out as a "failure mode" to be aware of)
+
+### Name explanation
+This is an alternate oclif, which is to say: "alt-oclif", which is to say "alto-clif".
+
+### Thanks
+
+Thanks to the [`@oclif` team and contributors](https://github.com/oclif/command/graphs/contributors).
+There are are lot of great ideas in oclif! Without them, of course, this package wouldn't exist!
+
+Original README info, below
+===============
+
 
 oclif base command
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
-  "name": "@oclif/command",
-  "description": "oclif base command",
-  "version": "1.5.14",
-  "author": "Jeff Dickey @jdxcode",
-  "bugs": "https://github.com/oclif/command/issues",
+  "name": "alto-command",
+  "description": "alto-clif base command",
+  "version": "0.9.0",
+  "oclif-version": "1.5.14",
+  "author": "柏大衛",
+  "oclif-author": "Jeff Dickey @jdxcode",
+  "bugs": "https://github.com/bodawei/alto-command/issues",
   "dependencies": {
     "@oclif/errors": "^1.2.2",
     "@oclif/parser": "3.8.1",
@@ -36,9 +38,10 @@
     "/flush.js",
     "/lib"
   ],
-  "homepage": "https://github.com/oclif/command",
+  "homepage": "https://github.com/bodawei/alto-command",
   "keywords": [
-    "oclif"
+    "oclif",
+    "alto-oclif"
   ],
   "license": "MIT",
   "main": "lib/index.js",
@@ -48,7 +51,7 @@
       "@oclif/plugin-plugins"
     ]
   },
-  "repository": "oclif/command",
+  "repository": "bodawei/alto-command",
   "scripts": {
     "build": "rm -rf lib && tsc",
     "lint": "tsc -p test --noEmit && tslint -p test -t stylish",


### PR DESCRIPTION
This adds very basic support for space-delimited subcommands.  See the README for more details.

This doesn't yet add tests for this new functionality.